### PR TITLE
NIIF feed was a broken link

### DIFF
--- a/etc/feeds.js
+++ b/etc/feeds.js
@@ -330,7 +330,7 @@
 		"zoom": 6
 	},
 	"niif": {
-		"url": "http://metadata.eduid.hu/metadata.xml",
+		"url": "https://metadata.eduid.hu/current/href.xml",
 		"country": "HU",
 		"CountrySearch": "Hungary",
 		"zoom": 7


### PR DESCRIPTION
Hi Andreas,

NIIF feed was pointing to a broken link (404).
Updated it to the working & current one.

Please update this in regard to the hosted feeds as this prevents
new idps to be added to the discovery service.

Thanks,
 cstamas
