### PR TITLE
Add the South African Identity Federation

### DIFF
--- a/etc/feeds.js
+++ b/etc/feeds.js
@@ -379,6 +379,15 @@
 		"info": "https://gridp.garr.it/",
 		"url": "https://gridp.garr.it/metadata/gridp.xml",
 		"country": "IT"
+	},
+	"safire": {
+		"url": "https://metadata.safire.ac.za/safire-idp-proxy-metadata.xml",
+		"title": "SAFIRE",
+		"descr": "South African Identity Federation",
+		"info": "https://safire.ac.za/",
+		"country": "ZA",
+		"CountrySearch": "South Africa",
+		"zoom": 6
 	}
 }
 


### PR DESCRIPTION
We are currently producing a local JSON feed for DiscoJuice to allow
IdPs that have opted not to participate in eduGAIN to make use of this.
However, the local feed format is limited and doesn't allow logos, etc.
So adding the federation here explicitly would allow for a more
consistant look and feel.

Metadata URL as documented at https://safire.ac.za/technical/metadata/